### PR TITLE
fix rspec deprecation message

### DIFF
--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -120,7 +120,7 @@ RSpec.configure do |config|
 
     begin
       match = example_group[:description_args].first.match(regex)
-      example_group = example_group[:example_group] unless match
+      example_group = example_group[:parent_example_group] unless match
     end while !match && example_group
 
     return example_group, match


### PR DESCRIPTION
Fixes error:
The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hash directly for the computed keys and `:parent_example_group` to access the parent example group metadata instead.